### PR TITLE
CA-5976: Disable SSL validation

### DIFF
--- a/boto/__init__.py
+++ b/boto/__init__.py
@@ -38,7 +38,7 @@ import logging.config
 from boto.compat import urlparse
 from boto.exception import InvalidUriError
 
-__version__ = '2.46.1'
+__version__ = '2.46.1.1'
 Version = __version__  # for backware compatibility
 
 # http://bugs.python.org/issue7980

--- a/boto/compat.py
+++ b/boto/compat.py
@@ -100,3 +100,17 @@ else:
                 result[decoded_name] = decoded_value
             return result
         return qs_dict
+
+
+# Create a wrapper function to get a non-validating SSL context (boto
+# implements its own certificate validation) on Python versions that
+# have that concept.
+try:
+    from ssl import create_default_context as _create_default_context
+    def create_non_validating_ssl_context(cafile=None):
+        ctx = _create_default_context(cafile=cafile)
+        ctx.check_hostname = False
+        return ctx
+except ImportError:
+    def create_non_validating_ssl_context(cafile=None):
+        return None

--- a/boto/connection.py
+++ b/boto/connection.py
@@ -752,8 +752,9 @@ class AWSAuthConnection(object):
                     host, ca_certs=self.ca_certificates_file,
                     **http_connection_kwargs)
             else:
-                connection = http_client.HTTPSConnection(
-                    host, **http_connection_kwargs)
+                connection = https_connection.NonCertValidatingHTTPSConnection(
+                    host, ca_certs=self.ca_certificates_file,
+                    **http_connection_kwargs)
         else:
             boto.log.debug('establishing HTTP connection: kwargs=%s' %
                            http_connection_kwargs)

--- a/tests/integration/s3/test_cert_verification.py
+++ b/tests/integration/s3/test_cert_verification.py
@@ -29,6 +29,7 @@ import unittest
 from tests.integration import ServiceCertVerificationTest
 
 import boto.s3
+import boto.s3.connection
 
 
 class S3CertVerificationTest(unittest.TestCase, ServiceCertVerificationTest):
@@ -37,3 +38,9 @@ class S3CertVerificationTest(unittest.TestCase, ServiceCertVerificationTest):
 
     def sample_service_call(self, conn):
         conn.get_all_buckets()
+        try:
+            conn.get_bucket("bucket.with.periods")
+        except boto.s3.connection.S3ResponseError:
+            # This may be a 403 or a 404, we don't care. What matters is that we
+            # don't get a certificate error.
+            pass


### PR DESCRIPTION
Since this is broken for buckets with dots in the bucket name.